### PR TITLE
Optimize book keeping for violated PL constraint selection

### DIFF
--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -132,11 +132,6 @@ private:
     List<PiecewiseLinearConstraint *> _plConstraints;
 
     /*
-      Piecewise linear constraints that are currently violated.
-    */
-    List<PiecewiseLinearConstraint *> _violatedPlConstraints;
-
-    /*
       A single, violated PL constraint, selected for fixing.
     */
     PiecewiseLinearConstraint *_plConstraintToFix;
@@ -254,11 +249,6 @@ private:
       Return true iff all variables are within bounds.
      */
     bool allVarsWithinBounds() const;
-
-    /*
-      Collect all violated piecewise linear constraints.
-    */
-    void collectViolatedPlConstraints();
 
     /*
       Return true iff all piecewise linear constraints hold.

--- a/src/engine/MaxConstraint.h
+++ b/src/engine/MaxConstraint.h
@@ -122,6 +122,8 @@ class MaxConstraint : public PiecewiseLinearConstraint
     */
     String serializeToString() const;
 
+    bool shouldBeInViolationSet() const;
+
  private:
     unsigned _f;
     Set<unsigned> _elements;

--- a/src/engine/PiecewiseLinearConstraint.cpp
+++ b/src/engine/PiecewiseLinearConstraint.cpp
@@ -18,6 +18,9 @@
 
 PiecewiseLinearConstraint::PiecewiseLinearConstraint()
     : _constraintActive( true )
+    , _violatedPlConstraints( NULL )
+    , _constraintToViolationCount( NULL )
+    , _violationPriorityQueue( NULL )
     , _constraintBoundTightener( NULL )
     , _statistics( NULL )
 {
@@ -31,6 +34,19 @@ void PiecewiseLinearConstraint::setStatistics( Statistics *statistics )
 void PiecewiseLinearConstraint::registerConstraintBoundTightener( IConstraintBoundTightener *tightener )
 {
     _constraintBoundTightener = tightener;
+}
+void PiecewiseLinearConstraint::registerViolationWatchers(
+  Set<PiecewiseLinearConstraint*>* violatedPlConstraints,
+  Map<PiecewiseLinearConstraint *, unsigned>* constraintToViolationCount,
+  Set<Pair<unsigned, PiecewiseLinearConstraint*> >* violationPriorityQueue)
+{
+  _violatedPlConstraints = violatedPlConstraints;
+  _constraintToViolationCount = constraintToViolationCount;
+  _violationPriorityQueue = violationPriorityQueue;
+  if ( shouldBeInViolationSet() ){
+    _violatedPlConstraints->insert( this );
+    // TODO
+  }
 }
 
 //

--- a/src/engine/PrecisionRestorer.cpp
+++ b/src/engine/PrecisionRestorer.cpp
@@ -54,7 +54,7 @@ void PrecisionRestorer::restorePrecision( IEngine &engine,
         engine.restoreState( _initialEngineState );
 
         // Re-add all splits, which will restore variables and equations
-        for ( const auto &split : targetSplits )
+        for ( const auto &split : targetSplits ) 
             engine.applySplit( split );
 
         // At this point, the tableau has the appropriate dimensions. Restore the variable bounds

--- a/src/engine/ReluConstraint.h
+++ b/src/engine/ReluConstraint.h
@@ -138,6 +138,8 @@ public:
     */
     String serializeToString() const;
 
+    bool shouldBeInViolationSet() const;
+
     /*
       Get the index of the B variable.
     */

--- a/src/engine/SmtCore.h
+++ b/src/engine/SmtCore.h
@@ -89,7 +89,11 @@ public:
       Have the SMT core choose, among a set of violated PL constraints, which
       constraint should be repaired (without splitting)
     */
-    PiecewiseLinearConstraint *chooseViolatedConstraintForFixing( List<PiecewiseLinearConstraint *> &_violatedPlConstraints ) const;
+    PiecewiseLinearConstraint *chooseViolatedConstraintForFixing() const;
+    void registerPLConstraint(PiecewiseLinearConstraint* plc) {
+      plc->registerViolationWatchers( &_violatedPlConstraints, &_constraintToViolationCount, &_violationPriorityQueue );
+    }
+    bool allPlConstraintsHold() const { return _violatedPlConstraints.empty();}
 
     /*
       For debugging purposes only - store a correct possible solution
@@ -140,9 +144,14 @@ private:
     PiecewiseLinearConstraint *_constraintForSplitting;
 
     /*
+      Piecewise linear constraints that are currently violated.
+    */
+    Set<PiecewiseLinearConstraint *> _violatedPlConstraints;
+    /*
       Count how many times each constraint has been violated.
     */
     Map<PiecewiseLinearConstraint *, unsigned> _constraintToViolationCount;
+    Set<Pair<unsigned, PiecewiseLinearConstraint*> > _violationPriorityQueue;
 
     static void log( const String &message );
 

--- a/src/engine/tests/Test_SmtCore.h
+++ b/src/engine/tests/Test_SmtCore.h
@@ -90,6 +90,11 @@ public:
             return true;
         }
 
+        bool shouldBeInViolationSet() const
+        {
+          return false;
+        }
+
         List<PiecewiseLinearConstraint::Fix> getPossibleFixes() const
         {
             return List<PiecewiseLinearConstraint::Fix>();


### PR DESCRIPTION
Updating book keeping for violated PL constraints in SMT Core. Each PLconstraint is registered as a watcher and eagerly report the change in status as the participating variables change.
