### PR TITLE
Build details with the version option

### DIFF
--- a/Rules.mk
+++ b/Rules.mk
@@ -3,7 +3,7 @@
 #
 
 GIT_HASH=`git rev-parse HEAD`
-GIT_BRANCH=`git rev-parse --abbrev-ref HEAD)`
+GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 MARABOU_VERSION=1.0.+
 export VERSION_FLAGS=-DGIT_HASH=\"$(GIT_HASH)\" -DGIT_BRANCH=\"$(GIT_BRANCH)\" -DMARABOU_VERSION=\"$(MARABOU_VERSION)\"
 

--- a/Rules.mk
+++ b/Rules.mk
@@ -2,6 +2,11 @@
 # Utilities
 #
 
+GIT_HASH=`git rev-parse HEAD`
+GIT_BRANCH=`git rev-parse --abbrev-ref HEAD)`
+MARABOU_VERSION=1.0.+
+export VERSION_FLAGS=-DGIT_HASH=\"$(GIT_HASH)\" -DGIT_BRANCH=\"$(GIT_BRANCH)\" -DMARABOU_VERSION=\"$(MARABOU_VERSION)\"
+
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 	COMPILER = g++
@@ -54,6 +59,9 @@ CFLAGS += \
 	-Werror \
 	-Wno-deprecated \
 	-std=c++0x \
+
+CFLAGS += \
+	$(VERSION_FLAGS) \
 
 %.obj: %.cpp
 	@echo "CC\t" $@

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -18,9 +18,33 @@
 #include "Marabou.h"
 #include "Options.h"
 
+
+static std::string getCompiler() {
+    std::stringstream ss;
+#ifdef __GNUC__
+    ss << "GCC";
+#else /* __GNUC__ */
+    ss << "unknown compiler";
+#endif /* __GNUC__ */
+#ifdef __VERSION__
+    ss << " version " << __VERSION__;
+#else /* __VERSION__ */
+    ss << ", unknown version";
+#endif /* __VERSION__ */
+    return ss.str();
+}
+
+static std::string getCompiledDateTime() {
+    return __DATE__ " " __TIME__;
+}
+
+
 void printVersion()
 {
-    std::cout << "Marabou version 1.0.0 " << std::endl;
+    std::cout << "Marabou version " << MARABOU_VERSION << " [" << GIT_BRANCH << " " << GIT_HASH << "]"
+	      << "\ncompiled with " << getCompiler()
+	      << "\non " << getCompiledDateTime()
+	      << std::endl;
 }
 
 


### PR DESCRIPTION
This PR adds the built details to the version option flag.

Here is how the output looks like:
```
./src/engine/marabou.elf --version
Marabou version 1.0.+ [branch-name b42baa8677a054dbaded5c56c9ecf6d0bc1d2b0a]
compiled with GCC version 8.3.0
on Aug 29 2019 14:26:29
```