### PR TITLE
Minor fix for printing

### DIFF
--- a/maraboupy/MarabouNetwork.py
+++ b/maraboupy/MarabouNetwork.py
@@ -245,7 +245,6 @@ class MarabouNetwork:
         Returns:
             outputValues: (np array) representing output of network
         """
-        print("Evaluating with Marabou\n")
         inputVars = self.inputVars # list of numpy arrays
         outputVars = self.outputVars
 

--- a/maraboupy/MarabouNetworkTF.py
+++ b/maraboupy/MarabouNetworkTF.py
@@ -528,7 +528,6 @@ class MarabouNetworkTF(MarabouNetwork.MarabouNetwork):
         Returns:
             outputValues: (np array) representing output of network
         """
-        print("Evaluating without Marabou")
         inputValuesReshaped = []
         for j in range(len(self.inputOps)):
             inputOp = self.inputOps[j]

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -210,7 +210,10 @@ bool Engine::solve( unsigned timeoutInSeconds )
                     if ( _tableau->getBasicAssignmentStatus() !=
                          ITableau::BASIC_ASSIGNMENT_JUST_COMPUTED )
                     {
-                        printf( "Before declaring SAT, recomputing...\n" );
+                        if ( _verbosity > 0)
+                        {
+                            printf( "Before declaring SAT, recomputing...\n" );
+                        }
                         // Make sure that the assignment is precise before declaring success
                         _tableau->computeAssignment();
                         continue;

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -210,7 +210,7 @@ bool Engine::solve( unsigned timeoutInSeconds )
                     if ( _tableau->getBasicAssignmentStatus() !=
                          ITableau::BASIC_ASSIGNMENT_JUST_COMPUTED )
                     {
-                        if ( _verbosity > 0)
+                        if ( _verbosity > 0 )
                         {
                             printf( "Before declaring SAT, recomputing...\n" );
                         }


### PR DESCRIPTION
This is really two very simple PRs merged into one, so I can split this up if needed.

There's a place in Engine.cpp that doesn't  check _verbosity before printing, which is fixed here. 

Also, maraboupy's function for evaluating a network at a point always prints a line that is not useful because it just tells the user that they called the function. When evaluating many points with maraboupy, this can result in a lot of print statements, so I think it's best to remove the print statement.