### PR TITLE
Consistent output format between DnC mode and the sequential mode

### DIFF
--- a/src/engine/DnCManager.cpp
+++ b/src/engine/DnCManager.cpp
@@ -230,6 +230,7 @@ String DnCManager::getResultString()
 
 void DnCManager::printResult()
 {
+    std::cout << std::endl;
     switch ( _exitCode )
     {
     case DnCManager::SAT:

--- a/src/engine/DnCManager.cpp
+++ b/src/engine/DnCManager.cpp
@@ -234,7 +234,7 @@ void DnCManager::printResult()
     {
     case DnCManager::SAT:
     {
-        std::cout << "SAT" << std::endl;
+        std::cout << "SAT\n" << std::endl;
 
         ASSERT( _engineWithSATAssignment != nullptr );
 

--- a/src/engine/DnCManager.cpp
+++ b/src/engine/DnCManager.cpp
@@ -102,7 +102,6 @@ void DnCManager::solve( unsigned timeoutInSeconds )
     if ( !createEngines() )
     {
         _exitCode = DnCManager::UNSAT;
-        printResult();
         return;
     }
 
@@ -163,7 +162,6 @@ void DnCManager::solve( unsigned timeoutInSeconds )
         thread.join();
 
     updateDnCExitCode();
-    printResult();
     return;
 }
 
@@ -236,7 +234,7 @@ void DnCManager::printResult()
     {
     case DnCManager::SAT:
     {
-        std::cout << "DnCManager::solve SAT query" << std::endl;
+        std::cout << "SAT" << std::endl;
 
         ASSERT( _engineWithSATAssignment != nullptr );
 
@@ -264,19 +262,19 @@ void DnCManager::printResult()
         break;
     }
     case DnCManager::UNSAT:
-        std::cout << "DnCManager::solve UNSAT query" << std::endl;
+        std::cout << "UNSAT" << std::endl;
         break;
     case DnCManager::ERROR:
-        std::cout << "DnCManager::solve ERROR" << std::endl;
+        std::cout << "ERROR" << std::endl;
         break;
     case DnCManager::NOT_DONE:
-        std::cout << "DnCManager::solve NOT_DONE" << std::endl;
+        std::cout << "NOT_DONE" << std::endl;
         break;
     case DnCManager::QUIT_REQUESTED:
-        std::cout << "DnCManager::solve QUIT_REQUESTED" << std::endl;
+        std::cout << "QUIT_REQUESTED" << std::endl;
         break;
     case DnCManager::TIMEOUT:
-        std::cout << "DnCManager::solve TIMEOUT" << std::endl;
+        std::cout << "TIMEOUT" << std::endl;
         break;
     default:
         ASSERT( false );

--- a/src/engine/DnCManager.h
+++ b/src/engine/DnCManager.h
@@ -62,6 +62,11 @@ public:
     */
     String getResultString();
 
+    /*
+      Print the result of DnC solving
+    */
+    void printResult();
+
 private:
     /*
       Create and run a DnCWorker
@@ -88,11 +93,6 @@ private:
       exitCode.
     */
     void updateDnCExitCode();
-
-    /*
-      Print the result of DnC solving
-    */
-    void printResult();
 
     /*
       Set _timeoutReached to true if timeout has been reached

--- a/src/engine/DnCMarabou.cpp
+++ b/src/engine/DnCMarabou.cpp
@@ -92,8 +92,8 @@ void DnCMarabou::run()
 void DnCMarabou::displayResults( unsigned long long microSecondsElapsed ) const
 {
     std::cout << "Total Time: " << microSecondsElapsed / 1000000 << std::endl;
+    _dncManager->printResult();
     String resultString = _dncManager->getResultString();
-
     // Create a summary file, if requested
     String summaryFilePath = Options::get()->getString( Options::SUMMARY_FILE );
     if ( summaryFilePath != "" )


### PR DESCRIPTION
Addressing https://github.com/guykatzz/Marabou/issues/154. Make the results printed out by DnCMarabou and Marabou be in the same format. 
