### PR TITLE
Changes for Windows that also affect Linux

### DIFF
--- a/src/common/Debug.h
+++ b/src/common/Debug.h
@@ -27,7 +27,7 @@
 #endif
 
 #ifdef DEBUG_ON
-#  define ASSERTM(x, y...)                         \
+#  define ASSERTM(x, y, ...)                     \
     {                                           \
         if ( !( x ) )                           \
         {                                       \
@@ -36,7 +36,7 @@
         }                                       \
     }
 #else
-#  define ASSERTM(x, y...)
+#  define ASSERTM(x, y, ...)
 #endif
 
 #ifdef DEBUG_ON

--- a/src/common/File.cpp
+++ b/src/common/File.cpp
@@ -22,8 +22,6 @@
 #include "T/unistd.h"
 #include <vector>
 
-
-
 File::File( const String &path ) : _path( path ), _descriptor( NO_DESCRIPTOR )
 {
 }
@@ -101,7 +99,6 @@ void File::write( const ConstSimpleData &data )
 
 void File::read( HeapData &buffer, unsigned maxReadSize )
 {
-
     std::vector<char> c(maxReadSize);
     char* readBuffer(c.data());
     int bytesRead;

--- a/src/common/File.cpp
+++ b/src/common/File.cpp
@@ -20,7 +20,7 @@
 #include "MStringf.h"
 #include "T/sys/stat.h"
 #include "T/unistd.h"
-#include <vector>
+#include "Vector.h"
 
 File::File( const String &path ) : _path( path ), _descriptor( NO_DESCRIPTOR )
 {
@@ -99,8 +99,8 @@ void File::write( const ConstSimpleData &data )
 
 void File::read( HeapData &buffer, unsigned maxReadSize )
 {
-    std::vector<char> c(maxReadSize);
-    char* readBuffer(c.data());
+    Vector<char> readVector( maxReadSize );
+    char *readBuffer( readVector.data() );
     int bytesRead;
 
     if ( ( bytesRead = T::read( _descriptor, readBuffer, sizeof(readBuffer) ) ) == -1 )

--- a/src/common/File.cpp
+++ b/src/common/File.cpp
@@ -20,6 +20,9 @@
 #include "MStringf.h"
 #include "T/sys/stat.h"
 #include "T/unistd.h"
+#include <vector>
+
+
 
 File::File( const String &path ) : _path( path ), _descriptor( NO_DESCRIPTOR )
 {
@@ -98,7 +101,9 @@ void File::write( const ConstSimpleData &data )
 
 void File::read( HeapData &buffer, unsigned maxReadSize )
 {
-    char readBuffer[maxReadSize];
+
+    std::vector<char> c(maxReadSize);
+    char* readBuffer(c.data());
     int bytesRead;
 
     if ( ( bytesRead = T::read( _descriptor, readBuffer, sizeof(readBuffer) ) ) == -1 )

--- a/src/common/MString.cpp
+++ b/src/common/MString.cpp
@@ -14,7 +14,7 @@
 **/
 
 #include "MString.h"
-#include <vector>
+#include "Vector.h"
 
 String::String( Super super ) : _super( super )
 {
@@ -108,9 +108,9 @@ List<String> String::tokenize( String delimiter ) const
 {
     List<String> tokens;
 
-    std::vector<char> c(length() + 1);
-    char* copy(c.data());
-    memcpy( copy, ascii(), sizeof(char)*(length()+1) );
+    Vector<char> copyVector( length() + 1 );
+    char *copy( copyVector.data() );
+    memcpy( copy, ascii(), sizeof(char) * ( length() + 1 ) );
 
     char *token = strtok( copy, delimiter.ascii() );
 

--- a/src/common/MString.cpp
+++ b/src/common/MString.cpp
@@ -14,6 +14,7 @@
 **/
 
 #include "MString.h"
+#include <vector>
 
 String::String( Super super ) : _super( super )
 {
@@ -107,8 +108,10 @@ List<String> String::tokenize( String delimiter ) const
 {
     List<String> tokens;
 
-    char copy[length()+1];
-    memcpy( copy, ascii(), sizeof(copy) );
+	std::vector<char> c(length() + 1);
+	char* copy(c.data());
+
+    memcpy( copy, ascii(), sizeof(char)*(length()+1) );
 
     char *token = strtok( copy, delimiter.ascii() );
 

--- a/src/common/MString.cpp
+++ b/src/common/MString.cpp
@@ -108,9 +108,8 @@ List<String> String::tokenize( String delimiter ) const
 {
     List<String> tokens;
 
-	std::vector<char> c(length() + 1);
-	char* copy(c.data());
-
+    std::vector<char> c(length() + 1);
+    char* copy(c.data());
     memcpy( copy, ascii(), sizeof(char)*(length()+1) );
 
     char *token = strtok( copy, delimiter.ascii() );

--- a/src/common/Vector.h
+++ b/src/common/Vector.h
@@ -42,6 +42,10 @@ public:
     {
     }
 
+    Vector<T>( unsigned size, T value ) : _container( size, value )
+    {
+    }
+
     virtual void append( T value )
     {
         _container.push_back( value );

--- a/src/common/Vector.h
+++ b/src/common/Vector.h
@@ -38,6 +38,10 @@ public:
     {
     }
 
+    Vector<T>( unsigned size ) : _container( size )
+    {
+    }
+
     virtual void append( T value )
     {
         _container.push_back( value );
@@ -50,6 +54,11 @@ public:
 
     virtual ~Vector()
     {
+    }
+
+    T *data()
+    {
+        return _container.data();
     }
 
     T get( int index ) const

--- a/src/common/tests/Test_FloatUtils.h
+++ b/src/common/tests/Test_FloatUtils.h
@@ -69,21 +69,24 @@ public:
     {
         TS_ASSERT( FloatUtils::wellFormed( -1 ) );
         TS_ASSERT( !FloatUtils::wellFormed( sqrt( -1 ) ) );
-        TS_ASSERT( !FloatUtils::wellFormed( 5.0 / 0.0 ) );
+        float zero = 0.0;
+        TS_ASSERT( !FloatUtils::wellFormed( 5.0 / zero ) );
     }
 
     void test_isnan()
     {
         TS_ASSERT( !FloatUtils::isNan( -1 ) );
         TS_ASSERT( FloatUtils::isNan( sqrt( -1 ) ) );
-        TS_ASSERT( !FloatUtils::isNan( 5.0 / 0.0 ) );
+        float zero = 0.0;
+        TS_ASSERT( !FloatUtils::isNan( 5.0 / zero ) );
     }
 
     void test_isinf()
     {
         TS_ASSERT( !FloatUtils::isInf( -1 ) );
         TS_ASSERT( !FloatUtils::isInf( sqrt( -1 ) ) );
-        TS_ASSERT( FloatUtils::isInf( 5.0 / 0.0 ) );
+        float zero = 0.0;
+        TS_ASSERT( FloatUtils::isInf( 5.0 / zero ) );
     }
 };
 

--- a/src/common/tests/Test_Vector.h
+++ b/src/common/tests/Test_Vector.h
@@ -35,6 +35,28 @@ public:
         TS_ASSERT_THROWS_NOTHING( delete mockErrno );
     }
 
+    void test_constructor_size()
+    {
+        unsigned size = 3;
+
+        Vector<double> vector( size );
+
+        TS_ASSERT_EQUALS( vector.size(), 3u );
+    }
+
+    void test_constructor_value()
+    {
+        unsigned size = 3;
+        double value = 10.0;
+
+        Vector<double> vector( size, value );
+
+        TS_ASSERT_EQUALS( vector.size(), 3u );
+        TS_ASSERT_EQUALS( vector[0], value );
+        TS_ASSERT_EQUALS( vector[1], value );
+        TS_ASSERT_EQUALS( vector[2], value );
+    }
+
     void test_brackets()
     {
         Vector<String> vector;

--- a/src/engine/DnCManager.cpp
+++ b/src/engine/DnCManager.cpp
@@ -245,7 +245,7 @@ void DnCManager::printResult()
         _engineWithSATAssignment->extractSolution( *( inputQuery ) );
 
         Vector<double> inputVector( inputQuery->getNumInputVariables() );
-        Vector<double> outputVector( inputQuery->getNumInputVariables() );
+        Vector<double> outputVector( inputQuery->getNumOutputVariables() );
         double *inputs( inputVector.data() );
         double *outputs( outputVector.data() );
 

--- a/src/engine/DnCManager.cpp
+++ b/src/engine/DnCManager.cpp
@@ -21,16 +21,16 @@
 #include "GetCPUData.h"
 #include "LargestIntervalDivider.h"
 #include "MStringf.h"
+#include "MarabouError.h"
 #include "PiecewiseLinearCaseSplit.h"
 #include "PropertyParser.h"
 #include "QueryDivider.h"
-#include "MarabouError.h"
 #include "TimeUtils.h"
+#include "Vector.h"
 #include <atomic>
 #include <chrono>
 #include <cmath>
 #include <thread>
-#include <vector>
 
 void DnCManager::dncSolve( WorkerQueue *workload, std::shared_ptr<Engine> engine,
                            std::atomic_uint &numUnsolvedSubQueries,
@@ -244,10 +244,10 @@ void DnCManager::printResult()
         InputQuery *inputQuery = _engineWithSATAssignment->getInputQuery();
         _engineWithSATAssignment->extractSolution( *( inputQuery ) );
 
-        std::vector<double> in(inputQuery->getNumInputVariables());
-        std::vector<double> out(inputQuery->getNumInputVariables());
-        double* inputs(in.data());
-        double* outputs(out.data());
+        Vector<double> inputVector( inputQuery->getNumInputVariables() );
+        Vector<double> outputVector( inputQuery->getNumInputVariables() );
+        double *inputs( inputVector.data() );
+        double *outputs( outputVector.data() );
 
         printf( "Input assignment:\n" );
         for ( unsigned i = 0; i < inputQuery->getNumInputVariables(); ++i )

--- a/src/engine/DnCManager.cpp
+++ b/src/engine/DnCManager.cpp
@@ -30,6 +30,7 @@
 #include <chrono>
 #include <cmath>
 #include <thread>
+#include <vector>
 
 void DnCManager::dncSolve( WorkerQueue *workload, std::shared_ptr<Engine> engine,
                            std::atomic_uint &numUnsolvedSubQueries,
@@ -243,9 +244,11 @@ void DnCManager::printResult()
         InputQuery *inputQuery = _engineWithSATAssignment->getInputQuery();
         _engineWithSATAssignment->extractSolution( *( inputQuery ) );
 
+        std::vector<double> in(inputQuery->getNumInputVariables());
+        std::vector<double> out(inputQuery->getNumInputVariables());
+        double* inputs(in.data());
+        double* outputs(out.data());
 
-        double inputs[inputQuery->getNumInputVariables()];
-        double outputs[inputQuery->getNumOutputVariables()];
         printf( "Input assignment:\n" );
         for ( unsigned i = 0; i < inputQuery->getNumInputVariables(); ++i )
         {

--- a/src/input_parsers/AcasNeuralNetwork.cpp
+++ b/src/input_parsers/AcasNeuralNetwork.cpp
@@ -16,6 +16,7 @@
 #include "AcasNeuralNetwork.h"
 #include "AcasNnet.h"
 #include "FloatUtils.h"
+#include "Vector.h"
 
 #include <iostream>
 
@@ -70,10 +71,10 @@ unsigned AcasNeuralNetwork::getLayerSize( unsigned layer ) const
 
 void AcasNeuralNetwork::evaluate( const Vector<double> &inputs, Vector<double> &outputs, unsigned outputSize ) const
 {
-    std::vector<double> in(inputs.size());
-    std::vector<double> out(inputs.size());
-    double *input(in.data());
-    double *output(out.data());
+    Vector<double> inputVector( inputs.size() );
+    Vector<double> outputVector( outputs.size() );
+    double *input( inputVector.data() );
+    double *output( outputVector.data() );
 
     memset( input, 0, num_inputs( _network ) );
     memset( output, 0, num_outputs( _network ) );

--- a/src/input_parsers/AcasNeuralNetwork.cpp
+++ b/src/input_parsers/AcasNeuralNetwork.cpp
@@ -76,8 +76,8 @@ void AcasNeuralNetwork::evaluate( const Vector<double> &inputs, Vector<double> &
     double *input( inputVector.data() );
     double *output( outputVector.data() );
 
-    memset( input, 0, num_inputs( _network ) );
-    memset( output, 0, num_outputs( _network ) );
+    std::fill_n( input, num_inputs( _network ), 0 );
+    std::fill_n( output, num_outputs( _network ), 0 );
 
     for ( unsigned i = 0; i < inputs.size();  ++i )
         input[i] = inputs.get( i );

--- a/src/input_parsers/AcasNeuralNetwork.cpp
+++ b/src/input_parsers/AcasNeuralNetwork.cpp
@@ -70,8 +70,10 @@ unsigned AcasNeuralNetwork::getLayerSize( unsigned layer ) const
 
 void AcasNeuralNetwork::evaluate( const Vector<double> &inputs, Vector<double> &outputs, unsigned outputSize ) const
 {
-    double input[inputs.size()];
-    double output[outputSize];
+    std::vector<double> in(inputs.size());
+    std::vector<double> out(inputs.size());
+    double *input(in.data());
+    double *output(out.data());
 
     memset( input, 0, num_inputs( _network ) );
     memset( output, 0, num_outputs( _network ) );

--- a/src/input_parsers/AcasNeuralNetwork.cpp
+++ b/src/input_parsers/AcasNeuralNetwork.cpp
@@ -71,8 +71,8 @@ unsigned AcasNeuralNetwork::getLayerSize( unsigned layer ) const
 
 void AcasNeuralNetwork::evaluate( const Vector<double> &inputs, Vector<double> &outputs, unsigned outputSize ) const
 {
-    Vector<double> inputVector( num_inputs( _network ) );
-    Vector<double> outputVector( num_outputs( _network ) );
+    Vector<double> inputVector( inputs.size() );
+    Vector<double> outputVector( outputSize );
     double *input( inputVector.data() );
     double *output( outputVector.data() );
 

--- a/src/input_parsers/AcasNeuralNetwork.cpp
+++ b/src/input_parsers/AcasNeuralNetwork.cpp
@@ -71,13 +71,10 @@ unsigned AcasNeuralNetwork::getLayerSize( unsigned layer ) const
 
 void AcasNeuralNetwork::evaluate( const Vector<double> &inputs, Vector<double> &outputs, unsigned outputSize ) const
 {
-    Vector<double> inputVector( inputs.size() );
-    Vector<double> outputVector( outputSize );
+    Vector<double> inputVector( inputs.size(), 0.0 );
+    Vector<double> outputVector( outputSize, 0.0 );
     double *input( inputVector.data() );
     double *output( outputVector.data() );
-
-    std::fill_n( input, num_inputs( _network ), 0 );
-    std::fill_n( output, num_outputs( _network ), 0 );
 
     for ( unsigned i = 0; i < inputs.size();  ++i )
         input[i] = inputs.get( i );

--- a/src/input_parsers/AcasNeuralNetwork.cpp
+++ b/src/input_parsers/AcasNeuralNetwork.cpp
@@ -71,8 +71,8 @@ unsigned AcasNeuralNetwork::getLayerSize( unsigned layer ) const
 
 void AcasNeuralNetwork::evaluate( const Vector<double> &inputs, Vector<double> &outputs, unsigned outputSize ) const
 {
-    Vector<double> inputVector( inputs.size() );
-    Vector<double> outputVector( outputs.size() );
+    Vector<double> inputVector( num_inputs( _network ) );
+    Vector<double> outputVector( num_outputs( _network ) );
     double *input( inputVector.data() );
     double *output( outputVector.data() );
 

--- a/src/input_parsers/PropertyParser.cpp
+++ b/src/input_parsers/PropertyParser.cpp
@@ -182,7 +182,7 @@ void PropertyParser::processSingleLine( const String &line, InputQuery &inputQue
             bool inputVariable = token.contains( "x" );
             bool outputVariable = token.contains( "y" );
 
-            if ( !( inputVariable xor outputVariable ) )
+            if ( !( inputVariable ^ outputVariable ) )
                 throw InputParserError( InputParserError::UNEXPECTED_INPUT, token.ascii() );
 
             List<String> subTokens;


### PR DESCRIPTION
This is the first of two pull requests so that Marabou can be compiled on a Windows machine using Visual Studio. This PR contains changes to files that affect compilation on all machines, whereas the other PR will only contain changes that affect compilation on a Windows machine.

There are four types of changes:
1. Adding a comma before "..." in macro argument list
2. Removing instances where arrays are initialized with variable length
3. Changing the divide-by-zero test to use a variable instead of hard-coded zero
4. "xor" to "^"

These are all small changes needed to compile on Windows with Visual Studio but are not Windows specific. I'm able to run tests and maraboupy successfully on my Linux machine with these changes added.