### PR TITLE
Patch to dnc python api

### DIFF
--- a/maraboupy/MarabouCore.cpp
+++ b/maraboupy/MarabouCore.cpp
@@ -233,8 +233,6 @@ PYBIND11_MODULE(MarabouCore, m) {
         .def("getNumberOfVariables", &InputQuery::getNumberOfVariables)
         .def("getNumInputVariables", &InputQuery::getNumInputVariables)
         .def("getNumOutputVariables", &InputQuery::getNumOutputVariables)
-        .def("markInputVariable", &InputQuery::markInputVariable)
-        .def("markOutputVariable", &InputQuery::markOutputVariable)
         .def("inputVariableByIndex", &InputQuery::inputVariableByIndex)
         .def("markInputVariable", &InputQuery::markInputVariable)
         .def("markOutputVariable", &InputQuery::markOutputVariable)

--- a/maraboupy/MarabouNetwork.py
+++ b/maraboupy/MarabouNetwork.py
@@ -174,9 +174,12 @@ class MarabouNetwork:
             assert u < self.numVars
             ipq.setUpperBound(u, self.upperBounds[u])
 
-        for i, var in enumerate(self.inputVars[0]):
+        inputVarsFlattened = (np.array(self.inputVars).reshape(-1))
+        outputVarsFlattened = (np.array(self.outputVars).reshape(-1))
+
+        for i, var in enumerate(inputVarsFlattened):
             ipq.markInputVariable(i, var)
-        for i, var in enumerate(self.outputVars[0]):
+        for i, var in enumerate(outputVarsFlattened):
             ipq.markOutputVariable(i, var)
 
         return ipq


### PR DESCRIPTION
Apparently these two PRs (https://github.com/guykatzz/Marabou/pull/198, https://github.com/guykatzz/Marabou/pull/195) which were both opened at one time added the same functionality to the python API that marks the input and output variables. So I'm removing this redundancy.