### PR TITLE
Choose python version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ list(FIND PYTHON_VERSIONS_SUPPORTED ${DEFAULT_PYTHON_VERSION} index)
 if(index EQUAL -1)
     message(FATAL_ERROR "python version must be one of ${PYTHON_VERSIONS_SUPPORTED}")
 endif()
-message("PYTHON_V: ${DEFAULT_PYTHON_VERSION}")
 
 set(MARABOU_LIB MarabouHelper)
 set(MARABOU_TEST_LIB MarabouHelperTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,14 @@ option(RUN_UNIT_TEST "run cxxtest unit testing" ON)
 option(RUN_MEMORY_TEST "run cxxtest unit testing with ASAN" ON)
 option(RUN_REGRESS_TEST "run regression tests" OFF)
 
+set(DEFAULT_PYTHON_VERSION "3" CACHE STRING "Default Python version 2/3")
+set(PYTHON_VERSIONS_SUPPORTED 2 3)
+list(FIND PYTHON_VERSIONS_SUPPORTED ${DEFAULT_PYTHON_VERSION} index)
+if(index EQUAL -1)
+    message(FATAL_ERROR "python version must be one of ${PYTHON_VERSIONS_SUPPORTED}")
+endif()
+message("PYTHON_V: ${DEFAULT_PYTHON_VERSION}")
+
 set(MARABOU_LIB MarabouHelper)
 set(MARABOU_TEST_LIB MarabouHelperTest)
 set(MARABOU_EXE Marabou${CMAKE_EXECUTABLE_SUFFIX})
@@ -163,8 +171,14 @@ else()
 endif()
 
 if (${BUILD_PYTHON})
+
     # This is suppose to set the PYTHON_EXECUTABLE variable
-    find_package(PythonInterp REQUIRED)
+    # First try to find the default python version
+    find_package(PythonInterp ${DEFAULT_PYTHON_VERSION})
+    if (NOT EXISTS ${PYTHON_EXECUTABLE})
+        # If the default didn't work just find any python version
+        find_package(PythonInterp REQUIRED)
+    endif()
     
     if (NOT EXISTS ${PYBIND11_DIR})
         message("didnt find pybind, getting it")

--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ Debug mode, simply run "cmake --build . --config Debug", and the executables wil
 written to build/Debug.
 
 ### Python API
-Using Marabou through the Python interface requires Python 3. It may be useful
-to set up a Python virtual environment, see
+It may be useful to set up a Python virtual environment, see
 [here](https://docs.python.org/3/tutorial/venv.html) for more information.
 
+The python interface was tested only on versions >3.5 and >2.7. The build process preffers python3 but will work if there is only python 2.7 avilable. (To control the default change the DEFAULT_PYTHON_VERSION variable).  
 The Python interface requires *pybind11* (which is automatically downloaded). 
 To also build the python API on Linux or MacOS, run:
 ```

--- a/maraboupy/tests.py
+++ b/maraboupy/tests.py
@@ -1,5 +1,6 @@
 from maraboupy import MarabouCore
-import pytest
+from maraboupy.Marabou import createOptions
+# import pytest
 
 large = 100
 def define_network():
@@ -36,13 +37,16 @@ def define_network():
 
 def test_solve_partial_arguments():
     network = define_network()
-    MarabouCore.solve(network)
+    options = createOptions()
+    MarabouCore.solve(network, options)
 
 def test_dump_query():
     network = define_network()
-    MarabouCore.solve(network, "", 0, 0)
+    options = createOptions()
+    MarabouCore.solve(network, options, "")
     network.dump()
 
 
 if __name__ == "__main__":
     test_dump_query()
+    test_solve_partial_arguments()


### PR DESCRIPTION
Add option to choose between python 2 and 3 (where default is 3)
If only one python version is installed will choose that, if both are installed will use the default.

Other then that fixed the tests.py example (after introducing MarabouOptions) which broke it.... 