### PR TITLE
Symbolic bound tightening over absolute values (#251)

### DIFF
--- a/src/engine/AbsoluteValueConstraint.cpp
+++ b/src/engine/AbsoluteValueConstraint.cpp
@@ -259,8 +259,10 @@ PiecewiseLinearCaseSplit AbsoluteValueConstraint::getValidCaseSplit() const
     return getNegativeSplit();
 }
 
-void AbsoluteValueConstraint::eliminateVariable( unsigned /* variable */, double /* fixedValue */ )
+void AbsoluteValueConstraint::eliminateVariable( unsigned variable, double /* fixedValue */ )
 {
+    ASSERT( variable = _b );
+
     // In an absolute value constraint, if a variable is removed the
     // entire constraint can be discarded
     _haveEliminatedVariables = true;

--- a/src/engine/Equation.cpp
+++ b/src/engine/Equation.cpp
@@ -30,12 +30,14 @@ bool Equation::Addend::operator==( const Addend &other ) const
 }
 
 Equation::Equation()
-    : _type( Equation::EQ )
+    : _scalar( 0 )
+    , _type( Equation::EQ )
 {
 }
 
 Equation::Equation( EquationType type )
-    : _type( type )
+    : _scalar( 0 )
+    , _type( type )
 {
 }
 

--- a/src/engine/NetworkLevelReasoner.cpp
+++ b/src/engine/NetworkLevelReasoner.cpp
@@ -13,6 +13,7 @@
 
  **/
 
+#include "AbsoluteValueConstraint.h"
 #include "Debug.h"
 #include "FloatUtils.h"
 #include "MStringf.h"
@@ -363,14 +364,20 @@ void NetworkLevelReasoner::evaluate( double *input, double *output )
             if ( _indexToWeightedSumVariable.exists( index ) )
                 _indexToWeightedSumAssignment[index] = _work2[targetNeuron];
 
-            // Apply activation function
-            if ( _neuronToActivationFunction.exists( index ) )
+            // Apply activation function, unless computing the output layer
+            if ( targetLayer != _numberOfLayers - 1 )
             {
+                ASSERT( _neuronToActivationFunction.exists( index ) );
+
                 switch ( _neuronToActivationFunction[index] )
                 {
                 case ReLU:
                     if ( _work2[targetNeuron] < 0 )
                         _work2[targetNeuron] = 0;
+                    break;
+
+                case AbsoluteValue:
+                    _work2[targetNeuron] = FloatUtils::abs( _work2[targetNeuron] );
                     break;
 
                 default:
@@ -650,8 +657,28 @@ void NetworkLevelReasoner::intervalArithmeticBoundPropagation()
                     _upperBoundsActivations[i][j] = ub;
                     break;
 
+                case AbsoluteValue:
+                    if ( lb > 0 )
+                    {
+                        _lowerBoundsActivations[i][j] = lb;
+                        _upperBoundsActivations[i][j] = ub;
+                    }
+                    else if ( ub < 0 )
+                    {
+                        _lowerBoundsActivations[i][j] = -ub;
+                        _upperBoundsActivations[i][j] = -lb;
+                    }
+                    else
+                    {
+                        // lb < 0 < ub
+                        _lowerBoundsActivations[i][j] = 0;
+                        _upperBoundsActivations[i][j] = FloatUtils::max( ub, -lb );
+                    }
+
+                    break;
+
                 default:
-                    ASSERT( false );
+                    throw MarabouError( MarabouError::NETWORK_LEVEL_REASONER_ACTIVATION_NOT_SUPPORTED );
                     break;
                 }
             }
@@ -825,108 +852,31 @@ void NetworkLevelReasoner::symbolicBoundPropagation()
             */
             if ( currentLayer < _numberOfLayers - 1 )
             {
-                /*
-                  There are two ways we can determine that a ReLU has become fixed:
+                // Propagate according to the specific activation function
+                Index index( currentLayer, i );
+                ASSERT( _neuronToActivationFunction.exists( index ) );
 
-                    1. If the ReLU's variables have been externally fixed
-                    2. lbLb >= 0 (ACTIVE) or ubUb <= 0 (INACTIVE)
-                */
-
-                ReluConstraint::PhaseStatus reluPhase = ReluConstraint::PHASE_NOT_FIXED;
-                if ( _eliminatedWeightedSumVariables.exists( Index( currentLayer, i ) ) )
+                switch ( _neuronToActivationFunction[index] )
                 {
-                    if ( _eliminatedWeightedSumVariables[Index( currentLayer, i )] <= 0 )
-                        reluPhase = ReluConstraint::PHASE_INACTIVE;
-                    else
-                        reluPhase = ReluConstraint::PHASE_ACTIVE;
+                case ReLU:
+                    reluSymbolicPropagation( index, lbLb, lbUb, ubLb, ubUb );
+                    break;
+
+                case AbsoluteValue:
+                    absoluteValueSymbolicPropagation( index, lbLb, lbUb, ubLb, ubUb );
+                    break;
+
+                default:
+                    throw MarabouError( MarabouError::NETWORK_LEVEL_REASONER_ACTIVATION_NOT_SUPPORTED );
+                    break;
                 }
-                else if ( _eliminatedActivationResultVariables.exists( Index( currentLayer, i ) ) )
-                {
-                    if ( FloatUtils::isZero( _eliminatedWeightedSumVariables[Index( currentLayer, i )] ) )
-                        reluPhase = ReluConstraint::PHASE_INACTIVE;
-                    else
-                        reluPhase = ReluConstraint::PHASE_ACTIVE;
-                }
-                else if ( _lowerBoundsWeightedSums[currentLayer][i] >= 0 )
-                    reluPhase = ReluConstraint::PHASE_ACTIVE;
-                else if ( _upperBoundsWeightedSums[currentLayer][i] <= 0 )
-                    reluPhase = ReluConstraint::PHASE_INACTIVE;
 
-                /*
-                  If the ReLU phase is not fixed yet, see whether the
-                  newly computed bounds imply that it should be fixed.
-                */
-                if ( reluPhase == ReluConstraint::PHASE_NOT_FIXED )
-                {
-                    // If we got here, we know that lbLb < 0 and ubUb
-                    // > 0 There are four possible cases, depending on
-                    // whether ubLb and lbUb are negative or positive
-                    // (see Neurify paper, page 14).
-
-                    // Upper bound
-                    if ( ubLb <= 0 )
-                    {
-                        // ubLb < 0 < ubUb
-                        // Concretize the upper bound using the Ehler's-like approximation
-                        for ( unsigned j = 0; j < _inputLayerSize; ++j )
-                            _currentLayerUpperBounds[j * currentLayerSize + i] =
-                                _currentLayerUpperBounds[j * currentLayerSize + i] * ubUb / ( ubUb - ubLb );
-
-                        // Do the same for the bias, and then adjust
-                        _currentLayerUpperBias[i] = _currentLayerUpperBias[i] * ubUb / ( ubUb - ubLb );
-                        _currentLayerUpperBias[i] -= ubLb * ubUb / ( ubUb - ubLb );
-                    }
-
-                    // Lower bound
-                    if ( lbUb <= 0 )
-                    {
-                        for ( unsigned j = 0; j < _inputLayerSize; ++j )
-                            _currentLayerLowerBounds[j * currentLayerSize + i] = 0;
-
-                        _currentLayerLowerBias[i] = 0;
-                    }
-                    else
-                    {
-                        for ( unsigned j = 0; j < _inputLayerSize; ++j )
-                            _currentLayerLowerBounds[j * currentLayerSize + i] =
-                                _currentLayerLowerBounds[j * currentLayerSize + i] * lbUb / ( lbUb - lbLb );
-
-                        _currentLayerLowerBias[i] = _currentLayerLowerBias[i] * lbUb / ( lbUb - lbLb );
-                    }
-
-                    lbLb = 0;
-                }
-                else
-                {
-                    // The phase of this ReLU is fixed!
-                    if ( reluPhase == ReluConstraint::PHASE_ACTIVE )
-                    {
-                        // Active ReLU, bounds are propagated as is
-                    }
-                    else
-                    {
-                        // Inactive ReLU, returns zero
-                        lbLb = 0;
-                        lbUb = 0;
-                        ubLb = 0;
-                        ubUb = 0;
-
-                        for ( unsigned j = 0; j < _inputLayerSize; ++j )
-                        {
-                            _currentLayerLowerBounds[j * currentLayerSize + i] = 0;
-                            _currentLayerUpperBounds[j * currentLayerSize + i] = 0;
-                        }
-                        _currentLayerLowerBias[i] = 0;
-                        _currentLayerUpperBias[i] = 0;
-                    }
-                }
+                // Store the bounds for this neuron
+                if ( _lowerBoundsActivations[currentLayer][i] < lbLb )
+                    _lowerBoundsActivations[currentLayer][i] = lbLb;
+                if ( _upperBoundsActivations[currentLayer][i] > ubUb )
+                    _upperBoundsActivations[currentLayer][i] = ubUb;
             }
-
-            // Store the bounds for this neuron
-            if ( _lowerBoundsActivations[currentLayer][i] < lbLb )
-                _lowerBoundsActivations[currentLayer][i] = lbLb;
-            if ( _upperBoundsActivations[currentLayer][i] > ubUb )
-                _upperBoundsActivations[currentLayer][i] = ubUb;
         }
 
         // Prepare for next iteration
@@ -935,6 +885,202 @@ void NetworkLevelReasoner::symbolicBoundPropagation()
         memcpy( _previousLayerLowerBias, _currentLayerLowerBias, sizeof(double) * _maxLayerSize );
         memcpy( _previousLayerUpperBias, _currentLayerUpperBias, sizeof(double) * _maxLayerSize );
     }
+}
+
+void NetworkLevelReasoner::reluSymbolicPropagation( const Index &index, double &lbLb, double &lbUb, double &ubLb, double &ubUb )
+{
+    /*
+      There are two ways we can determine that a ReLU has become fixed:
+
+      1. If the ReLU's variables have been externally fixed
+      2. lbLb >= 0 (ACTIVE) or ubUb <= 0 (INACTIVE)
+    */
+    unsigned currentLayer = index._layer;
+    unsigned i = index._neuron;
+    unsigned currentLayerSize = _layerSizes[currentLayer];
+
+    ReluConstraint::PhaseStatus reluPhase = ReluConstraint::PHASE_NOT_FIXED;
+    if ( _eliminatedWeightedSumVariables.exists( index ) )
+    {
+        if ( _eliminatedWeightedSumVariables[index] <= 0 )
+            reluPhase = ReluConstraint::PHASE_INACTIVE;
+        else
+            reluPhase = ReluConstraint::PHASE_ACTIVE;
+    }
+    else if ( _eliminatedActivationResultVariables.exists( index ) )
+    {
+        if ( FloatUtils::isZero( _eliminatedWeightedSumVariables[index] ) )
+            reluPhase = ReluConstraint::PHASE_INACTIVE;
+        else
+            reluPhase = ReluConstraint::PHASE_ACTIVE;
+    }
+    else if ( _lowerBoundsWeightedSums[currentLayer][i] >= 0 )
+        reluPhase = ReluConstraint::PHASE_ACTIVE;
+    else if ( _upperBoundsWeightedSums[currentLayer][i] <= 0 )
+        reluPhase = ReluConstraint::PHASE_INACTIVE;
+
+    /*
+      If the ReLU phase is not fixed yet, see whether the
+      newly computed bounds imply that it should be fixed.
+    */
+    if ( reluPhase == ReluConstraint::PHASE_NOT_FIXED )
+    {
+        // If we got here, we know that lbLb < 0 and ubUb
+        // > 0 There are four possible cases, depending on
+        // whether ubLb and lbUb are negative or positive
+        // (see Neurify paper, page 14).
+
+        // Upper bound
+        if ( ubLb <= 0 )
+        {
+            // ubLb < 0 < ubUb
+            // Concretize the upper bound using the Ehler's-like approximation
+            for ( unsigned j = 0; j < _inputLayerSize; ++j )
+                _currentLayerUpperBounds[j * currentLayerSize + i] =
+                    _currentLayerUpperBounds[j * currentLayerSize + i] * ubUb / ( ubUb - ubLb );
+
+            // Do the same for the bias, and then adjust
+            _currentLayerUpperBias[i] = _currentLayerUpperBias[i] * ubUb / ( ubUb - ubLb );
+            _currentLayerUpperBias[i] -= ubLb * ubUb / ( ubUb - ubLb );
+        }
+
+        // Lower bound
+        if ( lbUb <= 0 )
+        {
+            for ( unsigned j = 0; j < _inputLayerSize; ++j )
+                _currentLayerLowerBounds[j * currentLayerSize + i] = 0;
+
+            _currentLayerLowerBias[i] = 0;
+        }
+        else
+        {
+            for ( unsigned j = 0; j < _inputLayerSize; ++j )
+                _currentLayerLowerBounds[j * currentLayerSize + i] =
+                    _currentLayerLowerBounds[j * currentLayerSize + i] * lbUb / ( lbUb - lbLb );
+
+            _currentLayerLowerBias[i] = _currentLayerLowerBias[i] * lbUb / ( lbUb - lbLb );
+        }
+
+        lbLb = 0;
+    }
+    else
+    {
+        // The phase of this ReLU is fixed!
+        if ( reluPhase == ReluConstraint::PHASE_ACTIVE )
+        {
+            // Active ReLU, bounds are propagated as is
+        }
+        else
+        {
+            // Inactive ReLU, returns zero
+            lbLb = 0;
+            lbUb = 0;
+            ubLb = 0;
+            ubUb = 0;
+
+            for ( unsigned j = 0; j < _inputLayerSize; ++j )
+            {
+                _currentLayerLowerBounds[j * currentLayerSize + i] = 0;
+                _currentLayerUpperBounds[j * currentLayerSize + i] = 0;
+            }
+            _currentLayerLowerBias[i] = 0;
+            _currentLayerUpperBias[i] = 0;
+        }
+    }
+
+    if ( lbLb < 0 )
+        lbLb = 0;
+}
+
+void NetworkLevelReasoner::absoluteValueSymbolicPropagation( const Index &index, double &lbLb, double &lbUb, double &ubLb, double &ubUb )
+{
+    /*
+      There are two ways we can determine that an AbsoluteValue has become fixed:
+
+      1. If the weighted sum variable has been externally fixed
+      2. If the weighted sum bounds are lb >= 0 (POSITIVE) or ub <= 0 (NEGATIVE)
+    */
+    unsigned currentLayer = index._layer;
+    unsigned i = index._neuron;
+    unsigned currentLayerSize = _layerSizes[currentLayer];
+
+    AbsoluteValueConstraint::PhaseStatus absPhase = AbsoluteValueConstraint::PHASE_NOT_FIXED;
+    if ( _eliminatedWeightedSumVariables.exists( index ) )
+    {
+        if ( _eliminatedWeightedSumVariables[index] <= 0 )
+            absPhase = AbsoluteValueConstraint::PHASE_NEGATIVE;
+        else
+            absPhase = AbsoluteValueConstraint::PHASE_POSITIVE;
+    }
+    else if ( _lowerBoundsWeightedSums[currentLayer][i] >= 0 )
+        absPhase = AbsoluteValueConstraint::PHASE_POSITIVE;
+    else if ( _upperBoundsWeightedSums[currentLayer][i] <= 0 )
+        absPhase = AbsoluteValueConstraint::PHASE_NEGATIVE;
+
+    /*
+      If the phase is not fixed yet, see whether the
+      newly computed bounds imply that it should be fixed.
+    */
+    if ( absPhase == AbsoluteValueConstraint::PHASE_NOT_FIXED )
+    {
+        // If we got here, we know that lbLb < 0 < lbUb In this case,
+        // we do naive concretization: lb is 0, ub is the max between
+        // -lbLb and ubUb.
+        for ( unsigned j = 0; j < _inputLayerSize; ++j )
+            _currentLayerUpperBounds[j * currentLayerSize + i] = 0;
+
+        for ( unsigned j = 0; j < _inputLayerSize; ++j )
+            _currentLayerLowerBounds[j * currentLayerSize + i] = 0;
+
+        if ( -_currentLayerLowerBias[i] > _currentLayerUpperBias[i] )
+            _currentLayerUpperBias[i] = -_currentLayerLowerBias[i];
+
+        if ( -lbLb > ubUb )
+            ubUb = -lbLb;
+        lbLb = 0;
+
+        _currentLayerLowerBias[i] = lbLb;
+        _currentLayerUpperBias[i] = ubUb;
+    }
+    else
+    {
+        // The phase of this AbsoluteValueConstraint is fixed!
+        if ( absPhase == AbsoluteValueConstraint::PHASE_POSITIVE )
+        {
+            // Positive AbsoluteValue, bounds are propagated as is
+        }
+        else
+        {
+            // Negative AbsoluteValue, bounds are negated and flipped
+            double temp;
+            for ( unsigned j = 0; j < _inputLayerSize; ++j )
+            {
+                temp = _currentLayerUpperBounds[j * currentLayerSize + i];
+                _currentLayerUpperBounds[j * currentLayerSize + i] =
+                    -_currentLayerLowerBounds[j * currentLayerSize + i];
+                _currentLayerLowerBounds[j * currentLayerSize + i] = -temp;
+            }
+
+            temp = _currentLayerLowerBias[i];
+            _currentLayerLowerBias[i] = -_currentLayerUpperBias[i];
+            _currentLayerUpperBias[i] = -temp;
+
+            // Old lb, negated, is the new ub
+            temp = lbLb;
+            lbLb = -ubUb;
+            ubUb = -temp;
+
+            temp = lbUb;
+            lbUb = -ubLb;
+            ubLb = -temp;
+
+            // In extreme cases (constraint set externally), lbLb
+            // could be negative - so adjust this
+        }
+    }
+
+    if ( lbLb < 0 )
+        lbLb = 0;
 }
 
 void NetworkLevelReasoner::getConstraintTightenings( List<Tightening> &tightenings ) const

--- a/src/engine/NetworkLevelReasoner.h
+++ b/src/engine/NetworkLevelReasoner.h
@@ -66,6 +66,7 @@ public:
     */
     enum ActivationFunction {
         ReLU = 0,
+        AbsoluteValue = 1,
     };
 
     void setNumberOfLayers( unsigned numberOfLayers );
@@ -205,6 +206,13 @@ private:
     double *_previousLayerUpperBounds;
     double *_previousLayerLowerBias;
     double *_previousLayerUpperBias;
+
+    /*
+      Helper functions that perform symbolic bound propagation for a
+      single neuron, according to its activation function
+    */
+    void reluSymbolicPropagation( const Index &index, double &lbLb, double &lbUb, double &ubLb, double &ubUb );
+    void absoluteValueSymbolicPropagation( const Index &index, double &lbLb, double &lbUb, double &ubLb, double &ubUb );
 
     static void log( const String &message );
 };

--- a/src/engine/tests/Test_NetworkLevelReasoner.h
+++ b/src/engine/tests/Test_NetworkLevelReasoner.h
@@ -108,7 +108,7 @@ public:
         nlr.setNeuronActivationFunction( 2, 1, NetworkLevelReasoner::ReLU );
     }
 
-    void test_evaluate()
+    void test_evaluate_relus()
     {
         NetworkLevelReasoner nlr;
 
@@ -139,10 +139,48 @@ public:
         input[0] = 1;
         input[1] = 2;
 
+        nlr.setWeightedSumVariable( 2, 0, 8 );
+        nlr.setActivationResultVariable( 2, 0, 9 );
+        nlr.setWeightedSumVariable( 2, 1, 10 );
+        nlr.setActivationResultVariable( 2, 1, 11 );
+
         TS_ASSERT_THROWS_NOTHING( nlr.evaluate( input, output ) );
 
         TS_ASSERT( FloatUtils::areEqual( output[0], 0 ) );
         TS_ASSERT( FloatUtils::areEqual( output[1], 0 ) );
+    }
+
+    void test_evaluate_relus_and_abs()
+    {
+        NetworkLevelReasoner nlr;
+
+        populateNetwork( nlr );
+
+        // Override activation functions for the first hidden layer
+        nlr.setNeuronActivationFunction( 1, 0, NetworkLevelReasoner::AbsoluteValue );
+        nlr.setNeuronActivationFunction( 1, 1, NetworkLevelReasoner::AbsoluteValue );
+        nlr.setNeuronActivationFunction( 1, 2, NetworkLevelReasoner::AbsoluteValue );
+
+        nlr.setWeight( 1, 2, 1, -5 );
+
+        double input[2];
+        double output[2];
+
+        input[0] = 1;
+        input[1] = 1;
+
+        TS_ASSERT_THROWS_NOTHING( nlr.evaluate( input, output ) );
+
+        TS_ASSERT( FloatUtils::areEqual( output[0], 2 ) );
+        TS_ASSERT( FloatUtils::areEqual( output[1], 2 ) );
+
+        input[0] = 1;
+        input[1] = 2;
+
+        TS_ASSERT_THROWS_NOTHING( nlr.evaluate( input, output ) );
+
+        TS_ASSERT( FloatUtils::areEqual( output[0], 4 ) );
+        TS_ASSERT( FloatUtils::areEqual( output[1], 4 ) );
     }
 
     void test_store_into_other()
@@ -169,14 +207,6 @@ public:
         TS_ASSERT( FloatUtils::areEqual( output1[0], output2[0] ) );
         TS_ASSERT( FloatUtils::areEqual( output1[1], output2[1] ) );
 
-        // Set all neurons to ReLU, except for input and output neurons
-        nlr.setNeuronActivationFunction( 1, 0, NetworkLevelReasoner::ReLU );
-        nlr.setNeuronActivationFunction( 1, 1, NetworkLevelReasoner::ReLU );
-        nlr.setNeuronActivationFunction( 1, 2, NetworkLevelReasoner::ReLU );
-
-        nlr.setNeuronActivationFunction( 2, 0, NetworkLevelReasoner::ReLU );
-        nlr.setNeuronActivationFunction( 2, 1, NetworkLevelReasoner::ReLU );
-
         TS_ASSERT_THROWS_NOTHING( nlr.storeIntoOther( nlr2 ) );
 
         // With ReLUs, Inputs are zeros, only biases count
@@ -200,7 +230,7 @@ public:
         TS_ASSERT( FloatUtils::areEqual( output1[1], output2[1] ) );
     }
 
-    void test_interval_arithmetic_bound_propagation()
+    void test_interval_arithmetic_bound_propagation_relu_constraints()
     {
         NetworkLevelReasoner nlr;
         populateNetwork( nlr );
@@ -332,6 +362,145 @@ public:
         TS_ASSERT_EQUALS( expectedBounds2, bounds );
     }
 
+    void test_interval_arithmetic_bound_propagation_abs_constraints()
+    {
+        NetworkLevelReasoner nlr;
+        populateNetwork( nlr );
+
+        nlr.setNeuronActivationFunction( 1, 0, NetworkLevelReasoner::AbsoluteValue );
+        nlr.setNeuronActivationFunction( 1, 1, NetworkLevelReasoner::AbsoluteValue );
+        nlr.setNeuronActivationFunction( 1, 2, NetworkLevelReasoner::AbsoluteValue );
+
+        nlr.setNeuronActivationFunction( 2, 0, NetworkLevelReasoner::AbsoluteValue );
+        nlr.setNeuronActivationFunction( 2, 1, NetworkLevelReasoner::AbsoluteValue );
+
+        MockTableau tableau;
+
+        // Initialize the bounds
+        tableau.setLowerBound( 0, -1 );
+        tableau.setUpperBound( 0, 2 );
+        tableau.setLowerBound( 1, -1 );
+        tableau.setUpperBound( 1, 2 );
+
+        double large = 1000;
+        tableau.setLowerBound( 2, -large ); tableau.setUpperBound( 2, large );
+        tableau.setLowerBound( 3, -large ); tableau.setUpperBound( 3, large );
+        tableau.setLowerBound( 4, -large ); tableau.setUpperBound( 4, large );
+        tableau.setLowerBound( 5, -large ); tableau.setUpperBound( 5, large );
+        tableau.setLowerBound( 6, -large ); tableau.setUpperBound( 6, large );
+        tableau.setLowerBound( 7, -large ); tableau.setUpperBound( 7, large );
+        tableau.setLowerBound( 8, -large ); tableau.setUpperBound( 8, large );
+        tableau.setLowerBound( 9, -large ); tableau.setUpperBound( 9, large );
+        tableau.setLowerBound( 10, -large ); tableau.setUpperBound( 10, large );
+        tableau.setLowerBound( 11, -large ); tableau.setUpperBound( 11, large );
+        tableau.setLowerBound( 12, -large ); tableau.setUpperBound( 12, large );
+        tableau.setLowerBound( 13, -large ); tableau.setUpperBound( 13, large );
+
+        nlr.setTableau( &tableau );
+
+        // Initialize
+        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
+
+        // Perform the tightening pass
+        TS_ASSERT_THROWS_NOTHING( nlr.intervalArithmeticBoundPropagation() );
+
+        List<Tightening> expectedBounds({
+                Tightening( 2, 0, Tightening::LB ),
+                Tightening( 2, 3, Tightening::UB ),
+                Tightening( 3, 0, Tightening::LB ),
+                Tightening( 3, 3, Tightening::UB ),
+
+                Tightening( 4, -8, Tightening::LB ),
+                Tightening( 4, 7, Tightening::UB ),
+                Tightening( 5, 0, Tightening::LB ),
+                Tightening( 5, 8, Tightening::UB ),
+
+                Tightening( 6, -1, Tightening::LB ),
+                Tightening( 6, 2, Tightening::UB ),
+                Tightening( 7, 0, Tightening::LB ),
+                Tightening( 7, 2, Tightening::UB ),
+
+                Tightening( 8, -2, Tightening::LB ),
+                Tightening( 8, 11, Tightening::UB ),
+                Tightening( 9, 0, Tightening::LB ),
+                Tightening( 9, 11, Tightening::UB ),
+
+                Tightening( 10, -3, Tightening::LB ),
+                Tightening( 10, 10, Tightening::UB ),
+                Tightening( 11, 0, Tightening::LB ),
+                Tightening( 11, 10, Tightening::UB ),
+
+                Tightening( 12, 0, Tightening::LB ),
+                Tightening( 12, 11, Tightening::UB ),
+                Tightening( 13, 0, Tightening::LB ),
+                Tightening( 13, 41, Tightening::UB ),
+                    });
+
+        List<Tightening> bounds;
+        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
+        TS_ASSERT_EQUALS( expectedBounds, bounds );
+
+        // Change the current bounds
+        tableau.setLowerBound( 0, -3 );
+        tableau.setUpperBound( 0, 1 );
+        tableau.setLowerBound( 1, -1 );
+        tableau.setUpperBound( 1, 2 );
+
+        tableau.setLowerBound( 2, -large ); tableau.setUpperBound( 2, large );
+        tableau.setLowerBound( 3, -large ); tableau.setUpperBound( 3, large );
+        tableau.setLowerBound( 4, -large ); tableau.setUpperBound( 4, large );
+        tableau.setLowerBound( 5, -large ); tableau.setUpperBound( 5, large );
+        tableau.setLowerBound( 6, -large ); tableau.setUpperBound( 6, large );
+        tableau.setLowerBound( 7, -large ); tableau.setUpperBound( 7, large );
+        tableau.setLowerBound( 8, -large ); tableau.setUpperBound( 8, large );
+        tableau.setLowerBound( 9, -large ); tableau.setUpperBound( 9, large );
+        tableau.setLowerBound( 10, -large ); tableau.setUpperBound( 10, large );
+        tableau.setLowerBound( 11, -large ); tableau.setUpperBound( 11, large );
+        tableau.setLowerBound( 12, -large ); tableau.setUpperBound( 12, large );
+        tableau.setLowerBound( 13, -large ); tableau.setUpperBound( 13, large );
+
+        // Initialize
+        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
+
+        // Perform the tightening pass
+        TS_ASSERT_THROWS_NOTHING( nlr.intervalArithmeticBoundPropagation() );
+
+        List<Tightening> expectedBounds2({
+                Tightening( 2, -2, Tightening::LB ),
+                Tightening( 2, 2, Tightening::UB ),
+                Tightening( 3, 0, Tightening::LB ),
+                Tightening( 3, 2, Tightening::UB ),
+
+                Tightening( 4, -12, Tightening::LB ),
+                Tightening( 4, 5, Tightening::UB ),
+                Tightening( 5, 0, Tightening::LB ),
+                Tightening( 5, 12, Tightening::UB ),
+
+                Tightening( 6, -1, Tightening::LB ),
+                Tightening( 6, 2, Tightening::UB ),
+                Tightening( 7, 0, Tightening::LB ),
+                Tightening( 7, 2, Tightening::UB ),
+
+                Tightening( 8, -2, Tightening::LB ),
+                Tightening( 8, 14, Tightening::UB ),
+                Tightening( 9, 0, Tightening::LB ),
+                Tightening( 9, 14, Tightening::UB ),
+
+                Tightening( 10, -2, Tightening::LB ),
+                Tightening( 10, 14, Tightening::UB ),
+                Tightening( 11, 0, Tightening::LB ),
+                Tightening( 11, 14, Tightening::UB ),
+
+                Tightening( 12, 0, Tightening::LB ),
+                Tightening( 12, 14, Tightening::UB ),
+                Tightening( 13, 0, Tightening::LB ),
+                Tightening( 13, 56, Tightening::UB ),
+                    });
+
+        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
+        TS_ASSERT_EQUALS( expectedBounds2, bounds );
+    }
+
     void populateNetworkSBT( NetworkLevelReasoner &nlr, MockTableau &tableau )
     {
         /*
@@ -395,7 +564,7 @@ public:
         tableau.setLowerBound( 6, -large ); tableau.setUpperBound( 6, large );
     }
 
-    void test_sbt_all_active()
+    void test_sbt_relus_all_active()
     {
         NetworkLevelReasoner nlr;
         MockTableau tableau;
@@ -462,7 +631,7 @@ public:
             TS_ASSERT( expectedBounds.exists( bound ) );
     }
 
-    void test_sbt_active_and_inactive()
+    void test_sbt_relus_active_and_inactive()
     {
         NetworkLevelReasoner nlr;
         MockTableau tableau;
@@ -533,7 +702,7 @@ public:
             TS_ASSERT( expectedBounds.exists( bound ) );
     }
 
-    void test_sbt_active_and_not_fixed()
+    void test_sbt_relus_active_and_not_fixed()
     {
         NetworkLevelReasoner nlr;
         MockTableau tableau;
@@ -608,7 +777,7 @@ public:
             TS_ASSERT( expectedBounds.exists( bound ) );
     }
 
-    void test_sbt_active_and_externally_fixed()
+    void test_sbt_relus_active_and_externally_fixed()
     {
         NetworkLevelReasoner nlr;
         MockTableau tableau;
@@ -644,7 +813,7 @@ public:
           x3.lb =  x0 +  x1   : [5, 11]
           x3.ub =  x0 +  x1   : [5, 11]
 
-          First ReLU is inactive (set externalyl), bounds get zeroed
+          First ReLU is inactive (set externally), bounds get zeroed
           Second ReLU is active, bounds surive the activation
 
           x4.lb = 0
@@ -672,6 +841,306 @@ public:
 
                 Tightening( 6, -11, Tightening::LB ),
                 Tightening( 6, -5, Tightening::UB ),
+                    });
+
+        List<Tightening> bounds;
+        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
+
+        TS_ASSERT_EQUALS( expectedBounds.size(), bounds.size() );
+        for ( const auto &bound : bounds )
+            TS_ASSERT( expectedBounds.exists( bound ) );
+    }
+
+    void test_sbt_abs_all_positive()
+    {
+        NetworkLevelReasoner nlr;
+        MockTableau tableau;
+        nlr.setTableau( &tableau );
+        populateNetworkSBT( nlr, tableau );
+
+        nlr.setNeuronActivationFunction( 1, 0, NetworkLevelReasoner::ReLU );
+        nlr.setNeuronActivationFunction( 1, 1, NetworkLevelReasoner::ReLU );
+
+        tableau.setLowerBound( 0, 4 );
+        tableau.setUpperBound( 0, 6 );
+        tableau.setLowerBound( 1, 1 );
+        tableau.setUpperBound( 1, 5 );
+
+        // Invoke SBT
+        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
+        TS_ASSERT_THROWS_NOTHING( nlr.symbolicBoundPropagation() );
+
+        /*
+          Input ranges:
+
+          x0: [4, 6]
+          x1: [1, 5]
+
+          Layer 1:
+
+          x2.lb = 2x0 + 3x1   : [11, 27]
+          x2.ub = 2x0 + 3x1   : [11, 27]
+
+          x3.lb =  x0 +  x1   : [5, 11]
+          x3.ub =  x0 +  x1   : [5, 11]
+
+          Both absolute values positive, bound survive through activations:
+
+          x4.lb = 2x0 + 3x1   : [11, 27]
+          x4.ub = 2x0 + 3x1   : [11, 27]
+
+          x5.lb =  x0 +  x1   : [5, 11]
+          x5.ub =  x0 +  x1   : [5, 11]
+
+          Layer 2:
+
+          x6.lb =  x0 + 2x1   : [6, 16]
+          x6.ub =  x0 + 2x1   : [6, 16]
+        */
+
+        List<Tightening> expectedBounds({
+                Tightening( 2, 11, Tightening::LB ),
+                Tightening( 2, 27, Tightening::UB ),
+                Tightening( 3, 5, Tightening::LB ),
+                Tightening( 3, 11, Tightening::UB ),
+
+                Tightening( 4, 11, Tightening::LB ),
+                Tightening( 4, 27, Tightening::UB ),
+                Tightening( 5, 5, Tightening::LB ),
+                Tightening( 5, 11, Tightening::UB ),
+
+                Tightening( 6, 6, Tightening::LB ),
+                Tightening( 6, 16, Tightening::UB ),
+                    });
+
+        List<Tightening> bounds;
+        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
+
+        TS_ASSERT_EQUALS( expectedBounds.size(), bounds.size() );
+        for ( const auto &bound : bounds )
+            TS_ASSERT( expectedBounds.exists( bound ) );
+    }
+
+    void test_sbt_abs_positive_and_negative()
+    {
+        NetworkLevelReasoner nlr;
+        MockTableau tableau;
+        nlr.setTableau( &tableau );
+        populateNetworkSBT( nlr, tableau );
+
+        nlr.setNeuronActivationFunction( 1, 0, NetworkLevelReasoner::AbsoluteValue );
+        nlr.setNeuronActivationFunction( 1, 1, NetworkLevelReasoner::AbsoluteValue );
+
+        tableau.setLowerBound( 0, 4 );
+        tableau.setUpperBound( 0, 6 );
+        tableau.setLowerBound( 1, 1 );
+        tableau.setUpperBound( 1, 5 );
+
+        // Strong negative bias for x2, which is node (1,0)
+        nlr.setBias( 1, 0, -30 );
+
+        // Invoke SBT
+        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
+        TS_ASSERT_THROWS_NOTHING( nlr.symbolicBoundPropagation() );
+
+        /*
+          Input ranges:
+
+          x0: [4, 6]
+          x1: [1, 5]
+
+          Layer 1:
+
+          x2.lb = 2x0 + 3x1 - 30   : [-19, -3]
+          x2.ub = 2x0 + 3x1 - 30   : [-19, -3]
+
+          x3.lb =  x0 +  x1   : [5, 11]
+          x3.ub =  x0 +  x1   : [5, 11]
+
+          First absolute value is negative, bounds get flipped
+          Second absolute value is positive, bounds surive the activation
+
+          x4.lb = -2x0 -3x1 + 30   : [3, 19]
+          x4.ub = -2x0 -3x1 + 30   : [3, 19]
+
+          x5.lb =  x0 +  x1   : [5, 11]
+          x5.ub =  x0 +  x1   : [5, 11]
+
+          Layer 2:
+
+          x6.lb =  - 3x0 - 4x1 + 30  : [-8, 14]
+          x6.ub =  - 3x0 - 4x1 + 30  : [-8, 14]
+        */
+
+        List<Tightening> expectedBounds({
+                Tightening( 2, -19, Tightening::LB ),
+                Tightening( 2, -3, Tightening::UB ),
+                Tightening( 3, 5, Tightening::LB ),
+                Tightening( 3, 11, Tightening::UB ),
+
+                Tightening( 4, 3, Tightening::LB ),
+                Tightening( 4, 19, Tightening::UB ),
+                Tightening( 5, 5, Tightening::LB ),
+                Tightening( 5, 11, Tightening::UB ),
+
+                Tightening( 6, -8, Tightening::LB ),
+                Tightening( 6, 14, Tightening::UB ),
+                    });
+
+        List<Tightening> bounds;
+        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
+        TS_ASSERT_EQUALS( expectedBounds.size(), bounds.size() );
+
+        for ( const auto &bound : bounds )
+            TS_ASSERT( expectedBounds.exists( bound ) );
+    }
+
+    void test_sbt_absolute_values_positive_and_not_fixed()
+    {
+        NetworkLevelReasoner nlr;
+        MockTableau tableau;
+        nlr.setTableau( &tableau );
+        populateNetworkSBT( nlr, tableau );
+
+        nlr.setNeuronActivationFunction( 1, 0, NetworkLevelReasoner::AbsoluteValue );
+        nlr.setNeuronActivationFunction( 1, 1, NetworkLevelReasoner::AbsoluteValue );
+
+        tableau.setLowerBound( 0, 4 );
+        tableau.setUpperBound( 0, 6 );
+        tableau.setLowerBound( 1, 1 );
+        tableau.setUpperBound( 1, 5 );
+
+        // Strong negative bias for x2, which is node (1,0)
+        nlr.setBias( 1, 0, -15 );
+
+        // Invoke SBT
+        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
+        TS_ASSERT_THROWS_NOTHING( nlr.symbolicBoundPropagation() );
+
+        /*
+          Input ranges:
+
+          x0: [4, 6]
+          x1: [1, 5]
+
+          Layer 1:
+
+          x2.lb = 2x0 + 3x1 - 15   : [-4, 12]
+          x2.ub = 2x0 + 3x1 - 15   : [-4, 12]
+
+          x3.lb =  x0 +  x1   : [5, 11]
+          x3.ub =  x0 +  x1   : [5, 11]
+
+          First absolute value is undecided, bounds are concretized.
+          Second ReLU is active, bounds surive the activation
+
+          x4 range: [0, 12]
+          x4.lb = 0
+          x4.ub = 12
+
+          x5.lb =  x0 +  x1   : [5, 11]
+          x5.ub =  x0 +  x1   : [5, 11]
+
+          Layer 2:
+
+          x6.lb =  - x0 - x1       : [-11, -5]
+          x6.ub =  - x0 - x1 + 12  : [  1,  7]
+
+          x6 range: [-11, 7]
+        */
+
+        List<Tightening> expectedBounds({
+                Tightening( 2, -4, Tightening::LB ),
+                Tightening( 2, 12, Tightening::UB ),
+                Tightening( 3, 5, Tightening::LB ),
+                Tightening( 3, 11, Tightening::UB ),
+
+                Tightening( 4, 0, Tightening::LB ),
+                Tightening( 4, 12, Tightening::UB ),
+                Tightening( 5, 5, Tightening::LB ),
+                Tightening( 5, 11, Tightening::UB ),
+
+                Tightening( 6, -11, Tightening::LB ),
+                Tightening( 6, 7, Tightening::UB ),
+                    });
+
+        List<Tightening> bounds;
+        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
+
+        TS_ASSERT_EQUALS( expectedBounds.size(), bounds.size() );
+        for ( const auto &bound : bounds )
+            TS_ASSERT( expectedBounds.exists( bound ) );
+    }
+
+    void test_sbt_absolute_values_active_and_externally_fixed()
+    {
+        NetworkLevelReasoner nlr;
+        MockTableau tableau;
+        nlr.setTableau( &tableau );
+        populateNetworkSBT( nlr, tableau );
+
+        nlr.setNeuronActivationFunction( 1, 0, NetworkLevelReasoner::AbsoluteValue );
+        nlr.setNeuronActivationFunction( 1, 1, NetworkLevelReasoner::AbsoluteValue );
+
+        tableau.setLowerBound( 0, 4 );
+        tableau.setUpperBound( 0, 6 );
+        tableau.setLowerBound( 1, 1 );
+        tableau.setUpperBound( 1, 5 );
+
+        // Strong negative bias for x2, which is node (1,0). Should make the node unfixed.
+        nlr.setBias( 1, 0, -15 );
+
+        // However, the weighted sum variable has been eliminated
+        nlr.eliminateVariable( 2, -3 );
+
+        // Invoke SBT
+        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
+        TS_ASSERT_THROWS_NOTHING( nlr.symbolicBoundPropagation() );
+
+        /*
+          Input ranges:
+
+          x0: [4, 6]
+          x1: [1, 5]
+
+          Layer 1:
+
+          x2.lb = 2x0 + 3x1 - 15   : [-4, 12]
+          x2.ub = 2x0 + 3x1 - 15   : [-4, 12]
+
+          x3.lb =  x0 +  x1   : [5, 11]
+          x3.ub =  x0 +  x1   : [5, 11]
+
+          First absolute value is negative (set externally), bounds get flipped
+          Second absolute value is positive, bounds surive the activation
+
+          x4.lb = -2x0 - 3x1 + 15   : [-12, 4]
+          x4.ub = -2x0 - 3x1 + 15   : [-12, 4]
+
+          Bounds for x4: [0, 4]
+
+          x5.lb =  x0 +  x1   : [5, 11]
+          x5.ub =  x0 +  x1   : [5, 11]
+
+          Layer 2:
+
+          x6.lb =  - 3x0 - 4x1 + 15  : [-23, -1]
+          x6.ub =  - 3x0 - 4x1 + 15  : [-23, -1]
+        */
+
+        List<Tightening> expectedBounds({
+                // x2 does not appear, because it has been eliminated
+
+                Tightening( 3, 5, Tightening::LB ),
+                Tightening( 3, 11, Tightening::UB ),
+
+                Tightening( 4, 0, Tightening::LB ),
+                Tightening( 4, 4, Tightening::UB ),
+                Tightening( 5, 5, Tightening::LB ),
+                Tightening( 5, 11, Tightening::UB ),
+
+                Tightening( 6, -23, Tightening::LB ),
+                Tightening( 6, -1, Tightening::UB ),
                     });
 
         List<Tightening> bounds;

--- a/src/system_tests/Test_AbsoluteValue.h
+++ b/src/system_tests/Test_AbsoluteValue.h
@@ -175,6 +175,7 @@ public:
         {
             equation.addAddend( 1, numVariables + i );
         }
+        equation.setScalar( 0 );
         inputQuery.addEquation( equation );
 
         // Bound the maximal L1 change (delta)


### PR DESCRIPTION
* test

* basic interval artihmetic bound propagation

* another test case

* initialize an SBT within the NLR. Pass topology, weights and biases

* wip

* SBT functionality into NLR

* wip

* bug fix

* cleanup

* cleanup

* wip

* handle eliminated relus

* cleanup: remove symbolic bound tightener

* oops

* additional cleanup

* oops

* first unit test

* unit tests for NLR

* basic support for symbolic bound propagations over ABS constraints

* unit test - evalue abs + relus

* a test for interval bound propagation, for abs constraints

* unit tests, and some consequent corrections, to AbsConstraint SBT

* set lblb to 0 for both Relu and Abs

* always initialize the scalar to 0 by default

* consistency

* oops

Co-authored-by: Guy Katz <guykatz@cs.huji.ac.il>